### PR TITLE
feat: used signal as an attribute value

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "packageManager": "pnpm@7.12.1",
   "dependencies": {
-    "@preact/signals": "1.0.4",
+    "@preact/signals": "1.1.0",
     "preact": "10.11.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,7 +3,7 @@ lockfileVersion: 5.4
 specifiers:
   '@babel/core': 7.19.1
   '@preact/preset-vite': 2.4.0
-  '@preact/signals': 1.0.4
+  '@preact/signals': 1.1.0
   '@typescript-eslint/eslint-plugin': 5.38.0
   '@typescript-eslint/parser': 5.38.0
   eslint: 8.23.1
@@ -23,7 +23,7 @@ specifiers:
   vite-tsconfig-paths: 3.5.0
 
 dependencies:
-  '@preact/signals': 1.0.4_preact@10.11.0
+  '@preact/signals': 1.1.0_preact@10.11.0
   preact: 10.11.0
 
 devDependencies:
@@ -499,16 +499,16 @@ packages:
       - supports-color
     dev: true
 
-  /@preact/signals-core/1.1.1:
-    resolution: {integrity: sha512-otWUXVDAX2qWMBqBELvYBcEehBnta9zWhFZ+PZ3siL6LCu4Rk0u7q1bUgfTKPJjAbMYyPcIMoX/j34kDqcNlLg==}
+  /@preact/signals-core/1.2.0:
+    resolution: {integrity: sha512-GBjq/8WJkh/aenrEMvWIOr1lRfu6nb25er0m6r+4qVqKC85mXAYIbGHnoHTooNXCKxn2KEMUrATvN54MdMHE1A==}
     dev: false
 
-  /@preact/signals/1.0.4_preact@10.11.0:
-    resolution: {integrity: sha512-x3CCzVFQDj/BPg67R7fBegtF9/R9/AHNSiKI457Wd8YjVtFeemIdXRrDXEt3RDoALpFDJUqdlFBv7adlFIdbNA==}
+  /@preact/signals/1.1.0_preact@10.11.0:
+    resolution: {integrity: sha512-lW00Ny4q65o0BiymwbhPtIo9Fne8DUflvKVJBNwI6UeN8pZXWLdeZEr3YjMV5aXEP65Eh6yLhKQnn1jCSfzYug==}
     peerDependencies:
       preact: 10.x
     dependencies:
-      '@preact/signals-core': 1.1.1
+      '@preact/signals-core': 1.2.0
       preact: 10.11.0
     dev: false
 

--- a/src/ClockFace.tsx
+++ b/src/ClockFace.tsx
@@ -35,7 +35,7 @@ export const ClockFace = () => {
           })).map(({ isHour }, index, { length }) => (
             <Hand
               key={index}
-              transform={{ value: rotate(index / length, 0) }}
+              transform={rotate(index / length, 0)}
               className={
                 isHour
                   ? 'stroke-neutral-800 @dark:stroke-neutral-200 stroke-width-2'

--- a/src/Hand.tsx
+++ b/src/Hand.tsx
@@ -5,8 +5,7 @@ type HandProps = {
   length: number;
   limit?: number;
   stationary?: boolean;
-  // transform: ReadonlySignal<string>;
-  transform: Pick<ReadonlySignal<string>, 'value'>;
+  transform?: ReadonlySignal<string> | string;
 } & Omit<JSX.SVGAttributes<SVGLineElement>, 'transform'>;
 
 export const Hand = ({
@@ -14,12 +13,14 @@ export const Hand = ({
   length = 0,
   limit = 94,
   stationary,
-  transform: { value },
+  transform,
   ...rest
 }: HandProps) => (
   <line
     className={`stroke-cap-round ${className}`}
-    transform={value}
+    // https://github.com/preactjs/signals/issues/106
+    // @ts-expect-error Type 'ReadonlySignal<string>' is not assignable to type 'string'.ts(2322)
+    transform={transform}
     y1={stationary ? length - limit : undefined}
     y2={-(stationary ? limit : length)}
     {...rest}


### PR DESCRIPTION
- updated @preact/signals to 1.1.0
- this enables the usage of signals as attributes for SVG elements
- added expected TS error in Hand.tsx
- updated transform property of the Hand component to receive either ReadonlySignal<string> or string